### PR TITLE
Implement flexible date parsing in ifdb.py

### DIFF
--- a/Contents/Code/common.py
+++ b/Contents/Code/common.py
@@ -1,6 +1,8 @@
 import logging
 import os
+import re
 import threading
+from datetime import datetime
 
 PlexRoot          = Core.app_support_path
 CachePath         = os.path.join(PlexRoot, "Plug-in Support", "Data", "com.plexapp.agents.ifdb", "DataItems")
@@ -141,3 +143,43 @@ def GetPlexLibraries():
         Log.Root('[{}] id: {:>2}, type: {:<6}, agent: {:<30}, scanner: {:<30}, library: {:<24}, path: {}'.format('x' if directory.get("agent") == "com.plexapp.agents.ifdb" else ' ', directory.get("key"), directory.get('type'), directory.get("agent"), directory.get("scanner"), directory.get('title'), location.get("path")))
   except Exception as e:
     Log.Root("PLEX_LIBRARY_URL - Exception: '{}'".format(e))
+
+def parse_flexible_date(date_string):
+  """Parse dates in various formats to a datetime.date object."""
+  if not date_string:
+    return None
+
+  date_string = date_string.strip()
+
+  # Handle year range format (e.g., "2003/2004" or "2012 / 2013 / 2014")
+  if "/" in date_string:
+    # Split by slash and strip whitespace from each part
+    parts = [part.strip() for part in date_string.split("/")]
+
+    # Check if all parts are valid 4-digit years
+    is_valid_year_format = True
+    for part in parts:
+      if not re.match(r'^\d{4}$', part):
+        is_valid_year_format = False
+        break
+
+    if is_valid_year_format and parts:
+      # Get the last (most recent) year
+      latest_year = parts[-1]
+      return datetime.strptime(latest_year, "%Y").date()
+
+  formats = [
+    "%B %Y",       # Full month: "January 2022"
+    "%b %Y",       # Abbreviated month: "Dec 2022"
+    "%b. %Y",      # Abbreviated month with period: "Aug. 2022"
+    "%Y"           # Year only: "2008"
+  ]
+
+  for fmt in formats:
+    try:
+      return datetime.strptime(date_string, fmt).date()
+    except ValueError:
+      continue
+
+  # If none of the formats worked
+  raise ValueError("Could not parse date string: '{}'".format(date_string))

--- a/Contents/Code/ifdb.py
+++ b/Contents/Code/ifdb.py
@@ -1,11 +1,9 @@
-import time
 import urlparse
 
 import requests
 import common
 from common import Log
 from urlparse import urlparse
-from datetime import datetime
 
 # URLS
 IFDB_BASE_URL = 'https://fanedit.org/'
@@ -80,29 +78,32 @@ class IFDB:
 
   # entry extractors
   def entries_from_search_result(self, root_node):
-      Log.Info("###### IFDB.entries_from_search_result()  ###########")
-      results = []
-      entry_nodes = root_node.xpath('//*[@id="jr-pagenav-ajax"]/div[3]//div[contains(@class,"jrListingTitle")]/../..')
-      Log.Info("### Search Found: {} entries ###".format(len(entry_nodes)))
-      for entry in entry_nodes:
-        title = self.get_string_content_from_xpath(entry, './/div[contains(@class,"jrListingTitle")]//a/text()')
-        # ifdb_id = self.get_string_content_from_xpath(entry, './/div[contains(@class,"jrCompareButton")]/input/@value')
-        page_url = self.get_string_content_from_xpath(entry, './/div[contains(@class,"jrListingTitle")]/a/@href')
-        parsed_url = urlparse(page_url)
-        ifdb_id = parsed_url.path.replace('/', '')
-        thumb = self.get_string_content_from_xpath(entry, './/div[contains(@class,"jrListingThumbnail")]//img/@data-jr-src')
-        full_release_date = self.get_field_link_value(entry, "jrFaneditreleasedate")
-        release_date = datetime.strptime(full_release_date, "%B %Y").date()
-        entry = {
-          "id": ifdb_id,
-          "name": title,
-          "year": release_date.year,
-          "thumb": thumb,
-        }
-        results.append(entry)
-        Log.Info(("search entry: {}".format(entry)))
+    Log.Info("###### IFDB.entries_from_search_result()  ###########")
+    results = []
+    entry_nodes = root_node.xpath('//*[@id="jr-pagenav-ajax"]/div[3]//div[contains(@class,"jrListingTitle")]/../..')
+    Log.Info("### Search Found: {} entries ###".format(len(entry_nodes)))
+    for entry in entry_nodes:
+      title = self.get_string_content_from_xpath(entry, './/div[contains(@class,"jrListingTitle")]//a/text()')
+      # ifdb_id = self.get_string_content_from_xpath(entry, './/div[contains(@class,"jrCompareButton")]/input/@value')
+      page_url = self.get_string_content_from_xpath(entry, './/div[contains(@class,"jrListingTitle")]/a/@href')
+      parsed_url = urlparse(page_url)
+      ifdb_id = parsed_url.path.replace('/', '')
+      thumb = self.get_string_content_from_xpath(entry, './/div[contains(@class,"jrListingThumbnail")]//img/@data-jr-src')
+      full_release_date = self.get_field_link_value(entry, "jrFaneditreleasedate")
+      if full_release_date:
+        release_year = common.parse_flexible_date(full_release_date).year
+      else:
+        release_year = None
+      entry = {
+        "id": ifdb_id,
+        "name": title,
+        "year": release_year,
+        "thumb": thumb,
+      }
+      results.append(entry)
+      Log.Info(("search entry: {}".format(entry)))
 
-      return results
+    return results
 
   def entry_from_page_listing(self, root_node, extra_info=False):
     Log.Info("##### IFDB.entry_from_page_listing #####")
@@ -115,12 +116,12 @@ class IFDB:
     parsed_url = urlparse(page_url)
     ifdb_id = parsed_url.path.replace('/', '')
     Log.Info("### IFDB id: {}".format(ifdb_id))
-    thumbnail_url = self.get_string_content_from_xpath(banner_node, '//div[contains(@class,"jrListingMainImage")]/a//img/@data-jr-src')
+    thumbnail_url = self.get_string_content_from_xpath(banner_node, '//div[contains(@class,"jrListingMainImage")]/a//img/@src')
     Log.Info("### Thumbnail Url: {}".format(thumbnail_url))
     fields_node = banner_node.xpath('.//div[contains(@class,"jrCustomFields")]//div[contains(@class,"jrFaneditorname")]/../..')[0]
     full_release_date = self.get_string_content_from_xpath(fields_node, '//div[contains(@class,"jrFaneditreleasedate")]//a/text()')
     Log.Info("### Fanedit release date: {}".format(full_release_date))
-    release_date = datetime.strptime(full_release_date, "%B %Y").date()
+    release_date = common.parse_flexible_date(full_release_date)
     entry = {
       "id": str(ifdb_id),
       "name": title,
@@ -170,14 +171,14 @@ class IFDB:
 
     # Fanedit release year
     release_date_str = self.get_field_link_value(fields_node, "jrFaneditreleasedate")
-    release_date = datetime.strptime(release_date_str, "%B %Y").date()
+    release_date = common.parse_flexible_date(release_date_str)
     Log.Info("### Fanedit Release Date: {}".format(str(release_date)))
     info["fanedit_release_date"] = release_date
 
     # Original movie Release Date
     original_release_date_str = self.get_field_value(fields_node, "jrOriginalreleasedate")
     Log.Info("### Original Release Year: {}".format(original_release_date_str))
-    original_release_date = datetime.strptime(original_release_date_str, "%Y").date()
+    original_release_date = common.parse_flexible_date(original_release_date_str)
     info["original_release_date"] = original_release_date
 
     reviews_node = root_node.xpath('//div[@id="editorReviews"]')[0]


### PR DESCRIPTION
This pull request introduces improvements to date parsing and data extraction logic to make the codebase more robust when handling various date formats and thumbnail sources. The most significant change is the addition of a flexible date parsing utility, which is now used throughout the codebase to handle inconsistent date formats returned by the IFDB source. Additionally, the thumbnail extraction logic is updated for better reliability.

**Date parsing improvements:**

* Added the `parse_flexible_date` function in `common.py` to handle multiple date formats and year ranges, increasing resilience against inconsistent date strings from IFDB.
* Replaced all direct `datetime.strptime` calls with `common.parse_flexible_date` in `ifdb.py` for parsing fanedit and original release dates, ensuring consistent and error-tolerant date handling. [[1]](diffhunk://#diff-945c898bde7095bd381463c1f39ab9d51b949dc347b5c900ab9dd40355c2bfefL95-R100) [[2]](diffhunk://#diff-945c898bde7095bd381463c1f39ab9d51b949dc347b5c900ab9dd40355c2bfefL118-R124) [[3]](diffhunk://#diff-945c898bde7095bd381463c1f39ab9d51b949dc347b5c900ab9dd40355c2bfefL173-R181)

**Thumbnail extraction reliability:**

* Updated the XPath for extracting the thumbnail URL in `entry_from_page_listing` to use the `src` attribute instead of `data-jr-src`, improving compatibility with IFDB's HTML structure.

**Code cleanup:**

* Removed an unused import of `time` and the redundant import of `datetime` from `ifdb.py`, as date parsing is now handled by the new utility.

**General module enhancements:**

* Added imports for `re` and `datetime` in `common.py` to support the new date parsing functionality.